### PR TITLE
Additional tags for blocks and items

### DIFF
--- a/src/main/java/net/thefluffycart/litavis/datagen/ModBlockTagProvider.java
+++ b/src/main/java/net/thefluffycart/litavis/datagen/ModBlockTagProvider.java
@@ -2,6 +2,7 @@ package net.thefluffycart.litavis.datagen;
 
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider;
+import net.fabricmc.fabric.api.tag.convention.v2.ConventionalBlockTags;
 import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.registry.tag.BlockTags;
 import net.thefluffycart.litavis.block.ModBlocks;
@@ -42,29 +43,55 @@ public class ModBlockTagProvider extends FabricTagProvider.BlockTagProvider {
                 .add(ModBlocks.TRIPSLATE)
                 .add(ModBlocks.CALIBRATED_TRIPSLATE);
 
-        getOrCreateTagBuilder(BlockTags.WALLS).add(ModBlocks.GRANITE_BRICK_WALL);
-        getOrCreateTagBuilder(BlockTags.WALLS).add(ModBlocks.MOSSY_GRANITE_BRICK_WALL);
-        getOrCreateTagBuilder(BlockTags.WALLS).add(ModBlocks.CRACKED_GRANITE_BRICK_WALL);
-        getOrCreateTagBuilder(BlockTags.WALLS).add(ModBlocks.CRACKED_MOSSY_GRANITE_BRICK_WALL);
-        getOrCreateTagBuilder(BlockTags.WALLS).add(ModBlocks.TRIPSLATE_BRICK_WALL);
-        getOrCreateTagBuilder(BlockTags.WALLS).add(ModBlocks.CRACKED_TRIPSLATE_BRICK_WALL);
-        getOrCreateTagBuilder(BlockTags.WALLS).add(ModBlocks.MOSSY_TRIPSLATE_BRICK_WALL);
+        getOrCreateTagBuilder(BlockTags.STAIRS)
+                .add(ModBlocks.GRANITE_BRICK_STAIRS, ModBlocks.CRACKED_GRANITE_BRICK_STAIRS,
+                        ModBlocks.MOSSY_GRANITE_BRICK_STAIRS, ModBlocks.CRACKED_MOSSY_GRANITE_BRICK_STAIRS,
+                        ModBlocks.EUCALYPTUS_STAIRS, ModBlocks.TRIPSLATE_BRICK_STAIRS,
+                        ModBlocks.CRACKED_TRIPSLATE_BRICK_STAIRS, ModBlocks.MOSSY_TRIPSLATE_BRICK_STAIRS);
+
+        getOrCreateTagBuilder(BlockTags.SLABS)
+                .add(ModBlocks.GRANITE_BRICK_SLAB, ModBlocks.CRACKED_GRANITE_BRICK_SLAB,
+                        ModBlocks.MOSSY_GRANITE_BRICK_SLAB, ModBlocks.CRACKED_MOSSY_GRANITE_BRICK_SLAB,
+                        ModBlocks.EUCALYPTUS_SLAB, ModBlocks.TRIPSLATE_BRICK_SLAB,
+                        ModBlocks.CRACKED_TRIPSLATE_BRICK_SLAB, ModBlocks.MOSSY_TRIPSLATE_BRICK_SLAB);
+
+        getOrCreateTagBuilder(BlockTags.WALLS)
+                .add(ModBlocks.GRANITE_BRICK_WALL, ModBlocks.MOSSY_GRANITE_BRICK_WALL,
+                        ModBlocks.CRACKED_GRANITE_BRICK_WALL, ModBlocks.CRACKED_MOSSY_GRANITE_BRICK_WALL,
+                        ModBlocks.TRIPSLATE_BRICK_WALL, ModBlocks.CRACKED_TRIPSLATE_BRICK_WALL,
+                        ModBlocks.MOSSY_TRIPSLATE_BRICK_WALL);
 
         getOrCreateTagBuilder(BlockTags.SIGNS)
                 .add(ModBlocks.EUCALYPTUS_SIGN);
+
+        getOrCreateTagBuilder(BlockTags.WOODEN_BUTTONS).add(ModBlocks.EUCALYPTUS_BUTTON);
+        getOrCreateTagBuilder(BlockTags.WOODEN_PRESSURE_PLATES).add(ModBlocks.EUCALYPTUS_PRESSURE_PLATE);
+
+        getOrCreateTagBuilder(BlockTags.WOODEN_DOORS).add(ModBlocks.EUCALYPTUS_DOOR);
+        getOrCreateTagBuilder(BlockTags.WOODEN_TRAPDOORS).add(ModBlocks.EUCALYPTUS_TRAPDOOR);
 
         getOrCreateTagBuilder(BlockTags.FENCES).add(ModBlocks.EUCALYPTUS_FENCE);
         getOrCreateTagBuilder(BlockTags.FENCE_GATES).add(ModBlocks.EUCALYPTUS_FENCE_GATE);
 
         getOrCreateTagBuilder(BlockTags.MOSS_REPLACEABLE)
                 .add(ModBlocks.TRIPSLATE);
+
         getOrCreateTagBuilder(BlockTags.PLANKS)
                 .add(ModBlocks.EUCALYPTUS_PLANKS);
+
+        getOrCreateTagBuilder(BlockTags.SAPLINGS)
+                .add(ModBlocks.EUCALYPTUS_SAPLING);
 
         getOrCreateTagBuilder(BlockTags.LEAVES)
                 .add(ModBlocks.EUCALYPTUS_LEAVES);
 
         getOrCreateTagBuilder(BlockTags.LOGS)
                 .add(ModBlocks.EUCALYPTUS_LOG, ModBlocks.EUCALYPTUS_WOOD, ModBlocks.STRIPPED_EUCALYPTUS_LOG, ModBlocks.STRIPPED_EUCALYPTUS_WOOD);
+
+        getOrCreateTagBuilder(ConventionalBlockTags.STRIPPED_LOGS)
+                .add(ModBlocks.STRIPPED_EUCALYPTUS_LOG);
+
+        getOrCreateTagBuilder(ConventionalBlockTags.STRIPPED_WOODS)
+                .add(ModBlocks.STRIPPED_EUCALYPTUS_WOOD);
     }
 }

--- a/src/main/java/net/thefluffycart/litavis/datagen/ModItemTagProvider.java
+++ b/src/main/java/net/thefluffycart/litavis/datagen/ModItemTagProvider.java
@@ -2,6 +2,7 @@ package net.thefluffycart.litavis.datagen;
 
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider;
+import net.fabricmc.fabric.api.tag.convention.v2.ConventionalItemTags;
 import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.registry.tag.ItemTags;
 import net.thefluffycart.litavis.block.ModBlocks;
@@ -23,6 +24,18 @@ public class ModItemTagProvider extends FabricTagProvider.ItemTagProvider {
         getOrCreateTagBuilder(ItemTags.PLANKS)
                 .add(ModBlocks.EUCALYPTUS_PLANKS.asItem());
 
+        getOrCreateTagBuilder(ItemTags.DOORS)
+                .add(ModBlocks.EUCALYPTUS_DOOR.asItem());
+
+        getOrCreateTagBuilder(ItemTags.WOODEN_TRAPDOORS)
+                .add(ModBlocks.EUCALYPTUS_TRAPDOOR.asItem());
+
+        getOrCreateTagBuilder(ItemTags.SIGNS)
+                .add(ModItems.EUCALYPTUS_SIGN);
+
+        getOrCreateTagBuilder(ItemTags.HANGING_SIGNS)
+                .add(ModItems.HANGING_EUCALYPTUS_SIGN);
+
         getOrCreateTagBuilder(ItemTags.BOATS)
                 .add(ModItems.EUCALYPTUS_BOAT);
 
@@ -33,5 +46,8 @@ public class ModItemTagProvider extends FabricTagProvider.ItemTagProvider {
                 .add(ModItems.TERRAFORMER);
         getOrCreateTagBuilder(ItemTags.VANISHING_ENCHANTABLE)
                 .add(ModItems.TERRAFORMER);
+
+        getOrCreateTagBuilder(ItemTags.TRIM_TEMPLATES)
+                .add(ModItems.ENTOMBED_ARMOR_TRIM_SMITHING_TEMPLATE);
     }
 }


### PR DESCRIPTION
Many blocks and items, especially the mods wood type blocks and stairs and slabs were missing tags. This PR aims to fix that as much as possible.